### PR TITLE
Fix PDF modal render race and restore toolbar visibility in vue-pdf-viewer-core

### DIFF
--- a/src/components/PdfViewer.vue
+++ b/src/components/PdfViewer.vue
@@ -66,6 +66,7 @@ const renderTasks = new Map<
 const renderedPages = reactive(new Set<number>());
 const renderedScale = reactive(new Map<number, number>());
 const queuedPages = reactive(new Set<number>());
+const pendingCanvasPages = reactive(new Set<number>());
 const activeRenders = ref(0);
 const currentVirtualPages = ref(new Set<number>());
 const pageGapPx = ref(16);
@@ -153,6 +154,16 @@ function setCanvasRef(
   }
 
   canvasElements.set(pageNumber, element);
+
+  if (
+    pendingCanvasPages.has(pageNumber) &&
+    currentVirtualPages.value.has(pageNumber) &&
+    !renderedPages.has(pageNumber)
+  ) {
+    pendingCanvasPages.delete(pageNumber);
+    queuedPages.add(pageNumber);
+    void processRenderQueue();
+  }
 }
 
 function debounce<T extends (...args: never[]) => void>(
@@ -293,6 +304,7 @@ async function renderPage(
   const canvas = canvasElements.get(pageNumber);
 
   if (!canvas) {
+    pendingCanvasPages.add(pageNumber);
     return;
   }
   if (
@@ -466,6 +478,7 @@ function syncVirtualWindow(centerPage: number): void {
   for (const page of Array.from(queuedPages)) {
     if (!nextVirtualPages.has(page)) {
       queuedPages.delete(page);
+      pendingCanvasPages.delete(page);
     }
   }
 
@@ -547,6 +560,7 @@ async function loadPdf(): Promise<void> {
   renderedPages.clear();
   renderedScale.clear();
   queuedPages.clear();
+  pendingCanvasPages.clear();
   currentVirtualPages.value = new Set();
 
   try {

--- a/src/style.css
+++ b/src/style.css
@@ -3,6 +3,8 @@
   --lpv-panel: #e9e9e9;
   --lpv-border: #d1d1d1;
   --lpv-text: #1f1f1f;
+  --lpv-toolbar-text: #1f1f1f;
+  --lpv-icon-color: #1f1f1f;
 }
 
 .lpv-root {
@@ -144,6 +146,7 @@
   gap: 0.35rem;
   background: var(--lpv-panel);
   border-bottom: 0.0625rem solid var(--lpv-border);
+  color: var(--lpv-toolbar-text);
 }
 
 .lpv-group-nav-wrap {
@@ -190,7 +193,7 @@
   cursor: pointer;
   border: 0;
   background: transparent;
-  color: inherit;
+  color: var(--lpv-icon-color);
   transition: background-color 0.15s ease;
 }
 
@@ -370,4 +373,6 @@
   --lpv-panel: #3a3a3a;
   --lpv-border: #525252;
   --lpv-text: #f5f5f5;
+  --lpv-toolbar-text: #f5f5f5;
+  --lpv-icon-color: #f5f5f5;
 }


### PR DESCRIPTION
## Summary

  This PR fixes two issues seen when using the viewer inside modal-driven Nuxt layouts:

  1. Pages could stay blank because render was queued before canvas refs mounted.
  2. Toolbar icons could be invisible in host apps due to inherited color styles.

  ## Changes

  - Added a pending-canvas requeue path in PdfViewer so pages skipped before canvas mount are rendered once the canvas is
    available.
  - Kept virtual-window cleanup aligned by clearing pending entries when pages leave the active window.
  - Added explicit toolbar/icon color variables in viewer CSS to avoid host-style inheritance making icons disappear.

  ## Files

  - src/components/PdfViewer.vue
  - src/style.css

  ## Validation

  - npm run lint passed
  - npm test passed
  - npm run build passed

  ## Impact

  - No API changes.
  - Improves reliability for modal/open-late mount scenarios.
  - Improves visual consistency of toolbar icons across consuming apps.